### PR TITLE
#35-Fix / CreateRoutine 렌더링 오류 및 약간의 코드정리 완료

### DIFF
--- a/renderer/src/components/createRoutine/RoutineList/RoutineList.tsx
+++ b/renderer/src/components/createRoutine/RoutineList/RoutineList.tsx
@@ -2,7 +2,7 @@ import { useForm } from "react-hook-form";
 import * as LS from "../../../styles/createRoutine/RoutineList.styles";
 import useRoutine from "../../../firebase/hooks/Routine";
 import Paper from "@mui/material/Paper";
-import { MouseEvent, useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useRecoilState } from "recoil";
 import { ClickedRoutine, Routines } from "../../../recoilState/Routine/createRoutine";
 import { uuid } from "uuidv4";
@@ -13,31 +13,30 @@ export default function RoutineList() {
   const [routines, setRoutines] = useRecoilState<any>(Routines);
   const { createRoutine, DeleteRoutine } = useRoutine();
   const { register, handleSubmit } = useForm();
+
   // 첫 접속시 루틴리스트를 표시하기 위한 useEffect
   useEffect(() => {
-    let Routine = JSON.parse(sessionStorage.getItem("routine") || "");
-    let CopyRoutine = [...Routine];
-    setRoutines(CopyRoutine);
+    let routineData = JSON.parse(sessionStorage.getItem("routine") || "");
+    setRoutines([...routineData]);
   }, []);
 
   // 루틴을 1개 추가하기 위한 함수
   const onSubmitCreateRoutine = handleSubmit(async (data) => {
     await createRoutine(data.title);
-    setRoutines((prev: any) => [...prev, { title: data.title, list: [{ exercise: "", reps: "", sets: "", weight: "" }] }]);
+    setRoutines((prevRoutine: any) => [...prevRoutine, { title: data.title, list: [{ exercise: "", reps: "", sets: "", weight: "" }] }]);
   });
 
-  /** 루틴 리스트를 선택하면 해당하는 index가 GlobalState에 저장되는 함수 */
-  const onClickRoutineTitle = (event: MouseEvent<HTMLDivElement>) => {
-    setClickedRoutine(event.currentTarget.tabIndex);
+  /** 루틴 리스트를 클릭하면 클릭된 index가 GlobalState에 저장되는 함수 */
+  const onClickRoutineTitle = (index: number) => {
+    setClickedRoutine(index);
   };
 
-  const onClickDeleteRoutine = async () => {
+  /** 클릭된 루틴을 삭제하는 함수 */
+  const onClickDeleteRoutine = async (index: number) => {
     await DeleteRoutine();
-    let routines = JSON.parse(sessionStorage.getItem("routine") || "");
-    const IndexCount = clickedRoutine;
-    routines.splice(IndexCount, 1);
-    const NewRoutineList = routines;
-    setRoutines([...NewRoutineList]);
+    const updatedRoutines = [...routines];
+    updatedRoutines.splice(index, 1);
+    setRoutines(updatedRoutines);
     setClickedRoutine(0);
   };
   return (
@@ -51,13 +50,13 @@ export default function RoutineList() {
           <LS.SubmitBtn type="submit">추가</LS.SubmitBtn>
         </LS.InputWrapper>
         <LS.ListWrapper spacing={1}>
-          {routines.length !== 0 ? (
+          {routines.length > 0 ? (
             routines.map((item: any, index: number) => (
               <LS.ListBox key={uuid()}>
-                <LS.ListItem elevation={2} tabIndex={index} onClick={onClickRoutineTitle}>
+                <LS.ListItem elevation={2} onClick={() => onClickRoutineTitle(index)}>
                   {item.title}
                 </LS.ListItem>
-                {clickedRoutine === index ? <LS.Delete tabIndex={index} onClick={onClickDeleteRoutine}></LS.Delete> : <LS.HideIcon></LS.HideIcon>}
+                {clickedRoutine === index ? <LS.Delete onClick={() => onClickDeleteRoutine(index)}></LS.Delete> : <LS.HideIcon></LS.HideIcon>}
               </LS.ListBox>
             ))
           ) : (

--- a/renderer/src/components/createRoutine/RoutineTable/RoutineTable.tsx
+++ b/renderer/src/components/createRoutine/RoutineTable/RoutineTable.tsx
@@ -34,7 +34,7 @@ export default function RoutineTable() {
   });
   return isSsr ? (
     <TS.Wrapper component={Paper}>
-      {routines.length !== 0 ? (
+      {routines.length > 0 ? (
         <TS.FormWrapper onSubmit={onSubmitNewExercise}>
           <TS.Header variant="h4">{routines[clickedRoutine]?.title}</TS.Header>
           <TS.InputWrapper onSubmit={onSubmitNewExercise}>

--- a/renderer/src/firebase/hooks/Routine.js
+++ b/renderer/src/firebase/hooks/Routine.js
@@ -1,13 +1,7 @@
-import {
-  arrayUnion,
-  doc,
-  onSnapshot,
-  setDoc,
-  updateDoc,
-} from "firebase/firestore";
+import { arrayUnion, doc, onSnapshot, setDoc, updateDoc } from "firebase/firestore";
 import { useEffect, useState } from "react";
-import { useRecoilState } from "recoil";
-import { ClickedRoutine } from "../../recoilState/Routine/createRoutine";
+import { useRecoilState, useSetRecoilState } from "recoil";
+import { ClickedRoutine, Routines } from "../../recoilState/Routine/createRoutine";
 import { db } from "../firebase.config";
 
 export default function useRoutine() {
@@ -24,7 +18,7 @@ export default function useRoutine() {
     await updateDoc(RoutineRef, {
       routine: arrayUnion({
         title: title,
-        list: [{ exercise: "", weight: "", reps: "", sets: "" }],
+        list: [],
       }),
     });
     const unsub = onSnapshot(doc(db, "Routines", userUid), (doc) => {
@@ -33,13 +27,7 @@ export default function useRoutine() {
   };
 
   /** 루틴 내용(운동이름, 갯수 등)을 업데이트 하는 함수 */
-  const updateNewExercise = async (
-    clickedRoutine,
-    exercise,
-    weight,
-    reps,
-    sets
-  ) => {
+  const updateNewExercise = async (clickedRoutine, exercise, weight, reps, sets) => {
     let routines = JSON.parse(sessionStorage.getItem("routine"));
     let newExercise = {
       exercise: exercise,
@@ -61,6 +49,7 @@ export default function useRoutine() {
   };
 
   /** 오늘의 루틴을 완료하면 이전 루틴으로 저장되는 함수 */
+  const setRoutines = useSetRecoilState(Routines);
   const UpdatePrevRoutine = async (PrevRoutine) => {
     const UserRef = doc(db, "Users", userUid);
     await updateDoc(UserRef, {
@@ -83,6 +72,7 @@ export default function useRoutine() {
     const unsub = onSnapshot(doc(db, "Routines", userUid), (doc) => {
       sessionStorage.setItem("routine", JSON.stringify(doc.data().routine));
     });
+    setRoutines(NewRoutineList);
   };
   return { createRoutine, updateNewExercise, UpdatePrevRoutine, DeleteRoutine };
 }


### PR DESCRIPTION
## 작업 한 내용
1. createRoutine에서 Routine삭제시 2개씩 사라지지만 실제 데이터베이스에는 제대로 삭제되던 렌더링 오류를 해결
(과한 변,상수 사용과 RecoilState를 제거하고 index를 매개변수로 받는 것으로 해결했다. 아마도 RecoilState 때문에 렌더링이 2번되거나 splice된 배열이 제대로 저장되지않는? 문제가 생긴것 같다)
2. RoutineList의 코드를 약간 개선했다 불필요한 변수,상수설정을 삭제하고 state로 받아오던 index를 매개변수로 받게 변경
3. Routine.js에서 CreateRoutine시 빈 list배열을 저장하는 것으로 변경했다 이제 루틴을 생성하고 운동을 저장하면 테이블의 빈 공간이 사라진다.